### PR TITLE
Correct calendar metadata for GREGORIAN calendar type

### DIFF
--- a/time_manager/time_manager.F90
+++ b/time_manager/time_manager.F90
@@ -3253,7 +3253,8 @@ else if(ncal == THIRTY_DAY_MONTHS) then
 else if(ncal == JULIAN) then
   valid_calendar_types = 'JULIAN                  '
 else if(ncal == GREGORIAN) then
-  valid_calendar_types = 'GREGORIAN               '
+  ! The GREGORIAN calendar type actually implements PROLEPTIC_GREGORIAN
+  valid_calendar_types = 'PROLEPTIC_GREGORIAN     '
 else if(ncal == NOLEAP) then
   valid_calendar_types = 'NOLEAP                  '
 else


### PR DESCRIPTION
**Description**
The GREGORIAN calendar option actually implements a PROLEPTIC_GREGORIAN calendar. The changes in this PR mean that the calendar is correctly reported as PROLEPTIC_GREGORIAN in output files.

Fixes #9

See also https://github.com/mom-ocean/MOM5/issues/387, https://github.com/ACCESS-NRI/MOM5/issues/20, https://github.com/COSIMA/access-om2/issues/117, https://github.com/ACCESS-NRI/access-esm1.6-configs/issues/90

**How Has This Been Tested?**
Untested

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

