### PR TITLE
build: add FindNetCDF.cmake to cmake install directory (#1679)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,7 @@ export(EXPORT FMSExports
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FMSConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/fms-config.cmake
   INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/fms-config.cmake
+install(FILES ${CMAKE_SOURCE_DIR}/cmake/FindNetCDF.cmake ${CMAKE_CURRENT_BINARY_DIR}/fms-config.cmake
   DESTINATION ${CONFIG_INSTALL_DESTINATION})
 
 write_basic_package_version_file(

--- a/cmake/FMSConfig.cmake.in
+++ b/cmake/FMSConfig.cmake.in
@@ -22,7 +22,10 @@ if(@OPENMP@)
   find_dependency(OpenMP COMPONENTS C Fortran)
 endif()
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(NetCDF COMPONENTS C Fortran)
+list(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
 
 set(FMSVersion "${PACKAGE_VERSION}")
 set_and_check(FMS_INSTALL_PREFIX "${PACKAGE_PREFIX_DIR}")


### PR DESCRIPTION
Backport from upstream.

### Testing
```
[root@bd61902cc9ae opt]# spack install access-fms@git.mom5-update-cmake %intel@2021.10.0 target=x86_64
...
==> Waiting for access-fms-git.mom5-update-cmake=2025.04.001-git.3-awl5itye3n2cn==> Installing access-fms-git.mom5-update-cmake=2025.04.001-git.3-awl5itye3n2cnuru4ksjj2z2tlqxqwgv [31/31]
==> No binary for access-fms-git.mom5-update-cmake=2025.04.001-git.3-awl5itye3n2cnuru4ksjj2z2tlqxqwgv found: installing from source
==> No patches needed for access-fms
==> access-fms: Executing phase: 'cmake'
==> access-fms: Executing phase: 'build'
==> access-fms: Executing phase: 'install'
==> access-fms: Successfully installed access-fms-git.mom5-update-cmake=2025.04.001-git.3-awl5itye3n2cnuru4ksjj2z2tlqxqwgv
  Stage: 2.61s.  Cmake: 2.75s.  Build: 1m 27.15s.  Install: 0.12s.  Post-install: 0.12s.  Total: 1m 32.86s
[+] /opt/release/linux-rocky8-x86_64/intel-2021.10.0/access-fms-git.mom5-update-cmake_2025.04.001-git.3-awl5itye3n2cnuru4ksjj2z2tlqxqwgv
```

```
# ls -ltr /opt/release/linux-rocky8-x86_64/intel-2021.10.0/access-fms-git.mom5-update-cmake_2025.04.001-git.3-awl5itye3n2cnuru4ksjj2z2tlqxqwgv/lib64/cmake/fms/FindNetCDF.cmake 
-rw-r--r-- 1 root root 15449 May  2 03:52 /opt/release/linux-rocky8-x86_64/intel-2021.10.0/access-fms-git.mom5-update-cmake_2025.04.001-git.3-awl5itye3n2cnuru4ksjj2z2tlqxqwgv/lib64/cmake/fms/FindNetCDF.cmake
```