### PR TITLE
Add MOM5 REPRO flags to preserve answers with MOM5 internal FMS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ project(FMS
   LANGUAGES C Fortran)
 
 include(GNUInstallDirs)
+include(CheckFortranCompilerFlag)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
   message(STATUS "Setting build type to 'Release' as none was specified.")
@@ -63,6 +64,11 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
 
   # Copied from MOM5/bin/mkmf.template.nci.gfortran
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fcray-pointer -fdefault-real-8 -ffree-line-length-none -fno-range-check -Waliasing -Wampersand -Warray-bounds -Wcharacter-truncation -Wconversion -Wline-truncation -Wintrinsics-std -Wsurprising -Wno-tabs -Wunderflow -Wunused-parameter -Wintrinsic-shadow -Wno-align-commons")
+  # Note, -fallow-argument-mismatch is handled further down
+  check_fortran_compiler_flag("-fallow-invalid-boz" _boz_flag)
+  if(_boz_flag)
+    set(CMAKE_Fortran_FLAGS               "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz" )
+  endif()
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -W -fbounds-check")
 
@@ -74,7 +80,7 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
   set(r8_flags "${r8_flags} -no-prec-div -no-prec-sqrt")
 
   # Copied from MOM5/bin/mkmf.template.nci
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -fp-model precise -fp-model source -align all")
   set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -xCORE-AVX2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv")
 
@@ -85,7 +91,7 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
   set(r8_flags "-real-size 64") # Fortran flags for 64BIT precision
 
   # Copied from MOM5/bin/mkmf.template.nci
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -fp-model precise -fp-model source -align all")
   set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -xCORE-AVX2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv")
 
@@ -107,14 +113,14 @@ if(CMAKE_C_COMPILER_ID MATCHES "GNU")
 elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel")
 
   # Copied from MOM5/bin/mkmf.template.nci
-  set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -fp-model precise -fp-model source")
   set(CMAKE_C_FLAGS_DEBUG   "-O0 -g -ftrapuv -traceback")
   set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal -xCORE-AVX2")
 
 elseif(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
 
   # Copied from MOM5/bin/mkmf.template.nci
-  set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -fp-model precise")
   set(CMAKE_C_FLAGS_DEBUG   "-O0 -g -ftrapuv -traceback")
   set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal -xCORE-AVX2")
 
@@ -362,7 +368,6 @@ foreach(kind ${kinds})
   # Check if gnu 10 or higher
   # this should only be needed with mpich, but wasn't able to find a good way to find the MPI flavor consistently
   if ( CMAKE_Fortran_COMPILER_VERSION MATCHES "1[0-9]\.[0-9]*\.[0-9]*" AND CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-    include(CheckFortranCompilerFlag)
     check_fortran_compiler_flag("-fallow-argument-mismatch" _arg_mismatch_flag)
     if(_arg_mismatch_flag)
       message(STATUS "Adding -fallow-argument-mismatch flag to compile with GCC >=10 and MPICH")


### PR DESCRIPTION
**Description**
Without the changes in this PR, ACCESS models built with the "internal" FMS included in the MOM5 repo give different answers than ACCESS models using "external" FMS in this repo - see [here](https://github.com/ACCESS-NRI/access-om2-configs/pull/191#issuecomment-2857276987). This PR adds the MOM5 REPRO compiler flags so that answers can be preserved when moving from internal to external FMS.

**How Has This Been Tested?**
I have successfully reproduced answers from released versions of ACCESS-OM2 using these changes ([this change to the access-fms SPR](https://github.com/ACCESS-NRI/spack-packages/pull/237) is also needed if using Spack)

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

