### PR TITLE
Set hlv consistent with ESM1.6 UM and CICE

### DIFF
--- a/constants/constants.F90
+++ b/constants/constants.F90
@@ -49,7 +49,7 @@ real,               public, parameter :: RDGAS  = 287.05_r8_kind      !< Gas con
 real,               public, parameter :: RVGAS  = 461.50_r8_kind      !< Gas constant for water vapor [J/kg/deg]
 ! Extra:
 real,               public, parameter :: HLV      = 2.501e6_r8_kind   !< Latent heat of evaporation [J/kg]
-                                                                      !< Changed from 2.50e6 for consistency with CICE and the UM in ESM1.6
+                                                                      ! Changed from 2.50e6 for consistency with CICE and the UM in ESM1.6
 real,               public, parameter :: HLF      = 3.3358e5_r8_kind  !< Latent heat of fusion [J/kg]
 real,               public, parameter :: con_cliq = 4.1855e+3_r8_kind !< spec heat H2O liq [J/kg/K]
 real,               public, parameter :: con_csol = 2.1060e+3_r8_kind !< spec heat H2O ice [J/kg/K]
@@ -79,7 +79,7 @@ real,         public, parameter :: RDGAS  = 287.04_r8_kind           !< Gas cons
 real,         public, parameter :: RVGAS  = 461.50_r8_kind           !< Gas constant for water vapor [J/kg/deg]
 ! Extra:
 real,         public, parameter :: HLV = 2.501e6_r8_kind             !< Latent heat of evaporation [J/kg]
-                                                                     !< Changed from 2.50e6 for consistency with CICE and the UM in ESM1.6
+                                                                     ! Changed from 2.50e6 for consistency with CICE and the UM in ESM1.6
 real,         public, parameter :: HLF = 3.34e5_r8_kind              !< Latent heat of fusion [J/kg]
 real,         public, parameter :: KAPPA  = 2.0_r8_kind/7.0_r8_kind  !< RDGAS / CP_AIR [dimensionless]
 real,         public, parameter :: CP_AIR = RDGAS/KAPPA              !< Specific heat capacity of dry air at constant pressure [J/kg/deg]

--- a/constants/constants.F90
+++ b/constants/constants.F90
@@ -48,7 +48,7 @@ real(kind=r8_kind), public, parameter :: GRAV_8 = 9.80665_r8_kind     !< Acceler
 real,               public, parameter :: RDGAS  = 287.05_r8_kind      !< Gas constant for dry air [J/kg/deg]
 real,               public, parameter :: RVGAS  = 461.50_r8_kind      !< Gas constant for water vapor [J/kg/deg]
 ! Extra:
-real,               public, parameter :: HLV      = 2.5e6_r8_kind     !< Latent heat of evaporation [J/kg]
+real,               public, parameter :: HLV      = 2.501e6_r8_kind   !< Latent heat of evaporation [J/kg]
 real,               public, parameter :: HLF      = 3.3358e5_r8_kind  !< Latent heat of fusion [J/kg]
 real,               public, parameter :: con_cliq = 4.1855e+3_r8_kind !< spec heat H2O liq [J/kg/K]
 real,               public, parameter :: con_csol = 2.1060e+3_r8_kind !< spec heat H2O ice [J/kg/K]
@@ -77,7 +77,7 @@ real,         public, parameter :: GRAV   = 9.80_r8_kind             !< Accelera
 real,         public, parameter :: RDGAS  = 287.04_r8_kind           !< Gas constant for dry air [J/kg/deg]
 real,         public, parameter :: RVGAS  = 461.50_r8_kind           !< Gas constant for water vapor [J/kg/deg]
 ! Extra:
-real,         public, parameter :: HLV = 2.500e6_r8_kind             !< Latent heat of evaporation [J/kg]
+real,         public, parameter :: HLV = 2.501e6_r8_kind             !< Latent heat of evaporation [J/kg]
 real,         public, parameter :: HLF = 3.34e5_r8_kind              !< Latent heat of fusion [J/kg]
 real,         public, parameter :: KAPPA  = 2.0_r8_kind/7.0_r8_kind  !< RDGAS / CP_AIR [dimensionless]
 real,         public, parameter :: CP_AIR = RDGAS/KAPPA              !< Specific heat capacity of dry air at constant pressure [J/kg/deg]

--- a/constants/constants.F90
+++ b/constants/constants.F90
@@ -49,6 +49,7 @@ real,               public, parameter :: RDGAS  = 287.05_r8_kind      !< Gas con
 real,               public, parameter :: RVGAS  = 461.50_r8_kind      !< Gas constant for water vapor [J/kg/deg]
 ! Extra:
 real,               public, parameter :: HLV      = 2.501e6_r8_kind   !< Latent heat of evaporation [J/kg]
+                                                                      !< Changed from 2.50e6 for consistency with CICE and the UM in ESM1.6
 real,               public, parameter :: HLF      = 3.3358e5_r8_kind  !< Latent heat of fusion [J/kg]
 real,               public, parameter :: con_cliq = 4.1855e+3_r8_kind !< spec heat H2O liq [J/kg/K]
 real,               public, parameter :: con_csol = 2.1060e+3_r8_kind !< spec heat H2O ice [J/kg/K]
@@ -78,6 +79,7 @@ real,         public, parameter :: RDGAS  = 287.04_r8_kind           !< Gas cons
 real,         public, parameter :: RVGAS  = 461.50_r8_kind           !< Gas constant for water vapor [J/kg/deg]
 ! Extra:
 real,         public, parameter :: HLV = 2.501e6_r8_kind             !< Latent heat of evaporation [J/kg]
+                                                                     !< Changed from 2.50e6 for consistency with CICE and the UM in ESM1.6
 real,         public, parameter :: HLF = 3.34e5_r8_kind              !< Latent heat of fusion [J/kg]
 real,         public, parameter :: KAPPA  = 2.0_r8_kind/7.0_r8_kind  !< RDGAS / CP_AIR [dimensionless]
 real,         public, parameter :: CP_AIR = RDGAS/KAPPA              !< Specific heat capacity of dry air at constant pressure [J/kg/deg]


### PR DESCRIPTION
**Description**
This pull request updates the value for the latent heat of evaporation from 2.50e6 J/kg to 2.501e6 J/kg. This is done for consistency with the values used in UM and CICE in ESM1.6, and the change results in an improvement in the coupled model's water balance.

Closes #17

**How Has This Been Tested?**
This change has been tested in a 3 month run of ESM1.6. It results in no loss of water during the evaporation coupling:
<img width="990" height="299" alt="download-30" src="https://github.com/user-attachments/assets/097761f9-9927-4a07-8829-caeab9d85e0c" />


Compared to a loss of ~6.3e6kg/s without the change:
<img width="998" height="299" alt="download-29" src="https://github.com/user-attachments/assets/fbc03461-b594-4053-a463-3f2be427e6fe" />


**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] New check tests, if applicable, are included
- [ ] `make distcheck` passes

