### PR TITLE
Replace -xCORE-AVX2 with -mavx2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
 
   # Copied from MOM5/bin/mkmf.template.nci
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -fp-model precise -fp-model source -align all")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -xCORE-AVX2 -debug all -check none")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -mavx2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv")
 
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
@@ -92,7 +92,7 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
 
   # Copied from MOM5/bin/mkmf.template.nci
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -fp-model precise -fp-model source -align all")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -xCORE-AVX2 -debug all -check none")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -mavx2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv")
 
 else()
@@ -115,14 +115,14 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel")
   # Copied from MOM5/bin/mkmf.template.nci
   set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -fp-model precise -fp-model source")
   set(CMAKE_C_FLAGS_DEBUG   "-O0 -g -ftrapuv -traceback")
-  set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal -xCORE-AVX2")
+  set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal -mavx2")
 
 elseif(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
 
   # Copied from MOM5/bin/mkmf.template.nci
   set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -fp-model precise")
   set(CMAKE_C_FLAGS_DEBUG   "-O0 -g -ftrapuv -traceback")
-  set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal -xCORE-AVX2")
+  set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal -mavx2")
 
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
 
   # Copied from MOM5/bin/mkmf.template.nci
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -fp-model precise -fp-model source -align all")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -mavx2 -debug all -check none")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv")
 
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
@@ -92,7 +92,7 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
 
   # Copied from MOM5/bin/mkmf.template.nci
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -fp-model precise -fp-model source -align all")
-  set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -mavx2 -debug all -check none")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv")
 
 else()
@@ -115,14 +115,14 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel")
   # Copied from MOM5/bin/mkmf.template.nci
   set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -fp-model precise -fp-model source")
   set(CMAKE_C_FLAGS_DEBUG   "-O0 -g -ftrapuv -traceback")
-  set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal -mavx2")
+  set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal")
 
 elseif(CMAKE_C_COMPILER_ID STREQUAL "IntelLLVM")
 
   # Copied from MOM5/bin/mkmf.template.nci
   set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -fp-model precise")
   set(CMAKE_C_FLAGS_DEBUG   "-O0 -g -ftrapuv -traceback")
-  set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal -mavx2")
+  set(CMAKE_C_FLAGS_RELEASE "-O2 -debug minimal")
 
 elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
 

--- a/constants/constants.F90
+++ b/constants/constants.F90
@@ -48,8 +48,7 @@ real(kind=r8_kind), public, parameter :: GRAV_8 = 9.80665_r8_kind     !< Acceler
 real,               public, parameter :: RDGAS  = 287.05_r8_kind      !< Gas constant for dry air [J/kg/deg]
 real,               public, parameter :: RVGAS  = 461.50_r8_kind      !< Gas constant for water vapor [J/kg/deg]
 ! Extra:
-real,               public, parameter :: HLV      = 2.501e6_r8_kind   !< Latent heat of evaporation [J/kg]
-                                                                      ! Changed from 2.50e6 for consistency with CICE and the UM in ESM1.6
+real,               public, parameter :: HLV      = 2.5e6_r8_kind     !< Latent heat of evaporation [J/kg]
 real,               public, parameter :: HLF      = 3.3358e5_r8_kind  !< Latent heat of fusion [J/kg]
 real,               public, parameter :: con_cliq = 4.1855e+3_r8_kind !< spec heat H2O liq [J/kg/K]
 real,               public, parameter :: con_csol = 2.1060e+3_r8_kind !< spec heat H2O ice [J/kg/K]
@@ -78,8 +77,7 @@ real,         public, parameter :: GRAV   = 9.80_r8_kind             !< Accelera
 real,         public, parameter :: RDGAS  = 287.04_r8_kind           !< Gas constant for dry air [J/kg/deg]
 real,         public, parameter :: RVGAS  = 461.50_r8_kind           !< Gas constant for water vapor [J/kg/deg]
 ! Extra:
-real,         public, parameter :: HLV = 2.501e6_r8_kind             !< Latent heat of evaporation [J/kg]
-                                                                     ! Changed from 2.50e6 for consistency with CICE and the UM in ESM1.6
+real,         public, parameter :: HLV = 2.500e6_r8_kind             !< Latent heat of evaporation [J/kg]
 real,         public, parameter :: HLF = 3.34e5_r8_kind              !< Latent heat of fusion [J/kg]
 real,         public, parameter :: KAPPA  = 2.0_r8_kind/7.0_r8_kind  !< RDGAS / CP_AIR [dimensionless]
 real,         public, parameter :: CP_AIR = RDGAS/KAPPA              !< Specific heat capacity of dry air at constant pressure [J/kg/deg]


### PR DESCRIPTION
This is a redo of #19 from a branch on this repo so that the CI will run.

This will probably require some discussion. In #18 we changed the value of HLV from 2.50e6 J/kg to 2.501e6 J/kg for consistency with the UM and CICE in ESM1.6. The assumption/expectation was that we could avoid updating FMS in ACCESS-OM2. However, now we need to decide whether we:
- Add the ability to set HLV differently in ESM1.6 and OM2
- Leave as is and accept the small answer change in OM2