### PR TITLE
Add configurable prefix/separator for diag_manager wildcard file names

### DIFF
--- a/diag_manager/diag_data.F90
+++ b/diag_manager/diag_data.F90
@@ -702,6 +702,14 @@ MODULE diag_data_mod
   !   only supported if the diag_manager_init routine is called with the optional time_init parameter.
   !   This was usually done by FRE after the model run.
   ! </DATA>
+  ! <DATA NAME="wildcard_filename_prefix" TYPE="CHARACTER(len=16)" DEFAULT="'_'">
+  !   String inserted immediately before the first substituted time field when using a wildcard (%)
+  !   file name.
+  ! </DATA>
+  ! <DATA NAME="wildcard_filename_separator" TYPE="CHARACTER(len=16)" DEFAULT="'_'">
+  !   String inserted between each subsequent substituted time field when using a wildcard (%)
+  !   file name.
+  ! </DATA>
   ! <DATA NAME="region_out_use_alt_value" TYPE="LOGICAL" DEFAULT=".TRUE.">
   !   Will determine which value to use when checking a regional output if the region is the full axis or a sub-axis.
   !   The values are defined as <TT>GLO_REG_VAL</TT> (-999) and <TT>GLO_REG_VAL_ALT</TT> (-1) in <TT>diag_data_mod</TT>.
@@ -732,6 +740,10 @@ MODULE diag_data_mod
   INTEGER :: max_file_attributes = 2 !< Maximum number of user definable global attributes per file.
   INTEGER :: max_axis_attributes = 4 !< Maximum number of user definable attributes per axis.
   LOGICAL :: prepend_date = .TRUE. !< Should the history file have the start date prepended to the file name
+  CHARACTER(len=16) :: wildcard_filename_prefix = '_' !< String inserted immediately before the first
+                                                      !! substituted time field when using a wildcard (%)
+  CHARACTER(len=16) :: wildcard_filename_separator = '_' !< String inserted between each subsequent
+                                                         !! substituted time field when using a wildcard (%)
   LOGICAL :: write_manifest_file = .FALSE. !< Indicates if the manifest file should be written.  If writing many
                                            !! regional files, then the termination time may increase causing job to time out.
 

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -190,6 +190,14 @@ MODULE diag_manager_mod
   !      diag_manager_init routine is called with the optional time_init parameter.  Note: This was usually done by FRE after the
   !     model run.
   !   </DATA>
+  !   <DATA NAME="wildcard_filename_prefix" TYPE="CHARACTER(len=16)" DEFAULT="'_'">
+  !     String inserted immediately before the first substituted time field when using a wildcard (%)
+  !     file name.
+  !   </DATA>
+  !   <DATA NAME="wildcard_filename_separator" TYPE="CHARACTER(len=16)" DEFAULT="'_'">
+  !     String inserted between each subsequent substituted time field when using a wildcard (%)
+  !     file name.
+  !   </DATA>
   !   <DATA NAME="region_out_use_alt_value" TYPE="LOGICAL" DEFAULT=".TRUE.">
   !     Will determine which value to use when checking a regional output if the region is the full axis or a sub-axis.
   !     The values are defined as <TT>GLO_REG_VAL</TT> (-999) and <TT>GLO_REG_VAL_ALT</TT> (-1) in <TT>diag_data_mod</TT>.
@@ -229,7 +237,7 @@ MODULE diag_manager_mod
        & use_cmor, issue_oor_warnings, oor_warnings_fatal, oor_warning, pack_size,&
        & max_out_per_in_field, flush_nc_files, region_out_use_alt_value, max_field_attributes, output_field_type,&
        & max_file_attributes, max_axis_attributes, prepend_date, DIAG_FIELD_NOT_FOUND, diag_init_time, diag_data_init,&
-       & write_manifest_file
+       & write_manifest_file, wildcard_filename_prefix, wildcard_filename_separator
   USE diag_table_mod, ONLY: parse_diag_table
   USE diag_output_mod, ONLY: get_diag_global_att, set_diag_global_att
   USE diag_grid_mod, ONLY: diag_grid_init, diag_grid_end
@@ -3779,7 +3787,8 @@ CONTAINS
          & max_input_fields, max_axes, do_diag_field_log, write_bytes_in_file, debug_diag_manager,&
          & max_num_axis_sets, max_files, use_cmor, issue_oor_warnings,&
          & oor_warnings_fatal, max_out_per_in_field, flush_nc_files, region_out_use_alt_value, max_field_attributes,&
-         & max_file_attributes, max_axis_attributes, prepend_date, write_manifest_file
+         & max_file_attributes, max_axis_attributes, prepend_date, write_manifest_file,&
+         & wildcard_filename_prefix, wildcard_filename_separator
 
     ! If the module was already initialized do nothing
     IF ( module_is_initialized ) RETURN

--- a/diag_manager/diag_manager.F90
+++ b/diag_manager/diag_manager.F90
@@ -3872,6 +3872,17 @@ CONTAINS
        max_files = mpp_get_maxunits()
     END IF
 
+    ! wildcard_filename_prefix/separator are inserted directly into output file names, so must not
+    ! contain a directory separator
+    IF ( INDEX(TRIM(wildcard_filename_prefix), '/') > 0 ) THEN
+       CALL error_mesg('diag_manager_mod::diag_manager_init', 'DIAG_MANAGER_NML variable '//&
+            & 'wildcard_filename_prefix ("'//TRIM(wildcard_filename_prefix)//'") cannot contain "/"', FATAL)
+    END IF
+    IF ( INDEX(TRIM(wildcard_filename_separator), '/') > 0 ) THEN
+       CALL error_mesg('diag_manager_mod::diag_manager_init', 'DIAG_MANAGER_NML variable '//&
+            & 'wildcard_filename_separator ("'//TRIM(wildcard_filename_separator)//'") cannot contain "/"', FATAL)
+    END IF
+
     ! How to handle Out of Range Warnings.
     IF ( oor_warnings_fatal ) THEN
        oor_warning = FATAL

--- a/diag_manager/diag_util.F90
+++ b/diag_manager/diag_util.F90
@@ -52,7 +52,7 @@ MODULE diag_util_mod
        & mix_snapshot_average_fields, global_descriptor, CMOR_MISSING_VALUE, use_cmor, pack_size,&
        & debug_diag_manager, flush_nc_files, output_field_type, max_field_attributes, max_file_attributes,&
        & file_type, prepend_date, region_out_use_alt_value, GLO_REG_VAL, GLO_REG_VAL_ALT,&
-       & DIAG_FIELD_NOT_FOUND, diag_init_time
+       & DIAG_FIELD_NOT_FOUND, diag_init_time, wildcard_filename_prefix, wildcard_filename_separator
   USE diag_axis_mod, ONLY: get_diag_axis_data, get_axis_global_length, get_diag_axis_cart,&
        & get_domain1d, get_domain2d, diag_subaxes_init, diag_axis_init, get_diag_axis, get_axis_aux,&
        & get_axes_shift, get_diag_axis_name, get_diag_axis_domain_name, get_domainUG, &
@@ -2228,12 +2228,14 @@ CONTAINS
     INTEGER :: abs_sec, abs_day              ! component of current_time
     INTEGER :: days_per_month(12) = (/31,28,31,30,31,30,31,31,30,31,30,31/)
     INTEGER :: julian_day, i, position, len, first_percent
+    LOGICAL :: field_written  ! has a field already been appended to get_time_string
     CHARACTER(len=1) :: width  ! width of the field in format write
-    CHARACTER(len=10) :: format
+    CHARACTER(len=6) :: format
     CHARACTER(len=20) :: yr, mo, dy, hr, mi, sc        ! string of current time (output)
+    CHARACTER(len=20), DIMENSION(6) :: fields          ! yr, mo, dy, hr, mi, sc, in order
     CHARACTER(len=128) :: filetail
 
-    format = '("_",i*.*)'
+    format = '(i*.*)'
     CALL get_date(current_time, yr1, mo1, dy1, hr1, mi1, sc1)
     len = LEN_TRIM(filename)
     first_percent = INDEX(filename, '%')
@@ -2243,7 +2245,7 @@ CONTAINS
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
        yr1_s = yr1
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(yr, format) yr1_s
        yr2 = 0
     ELSE
@@ -2255,7 +2257,7 @@ CONTAINS
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
        mo1_s = yr2*12 + mo1
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(mo, format) mo1_s
     ELSE
        mo = ' '
@@ -2286,7 +2288,7 @@ CONTAINS
     position = INDEX(filetail, 'dy')
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
-       FORMAT(7:9) = width//'.'//width
+       FORMAT(3:5) = width//'.'//width
        WRITE(dy, FORMAT) dy1_s
     ELSE
        dy = ' '
@@ -2301,7 +2303,7 @@ CONTAINS
     position = INDEX(filetail, 'hr')
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(hr, format) hr1_s
     ELSE
        hr = ' '
@@ -2316,7 +2318,7 @@ CONTAINS
     position = INDEX(filetail, 'mi')
     IF(position>0) THEN
        width = filetail(position-1:position-1)
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(mi, format) mi1_s
     ELSE
        mi = ' '
@@ -2330,12 +2332,26 @@ CONTAINS
     position = INDEX(filetail, 'sc')
     IF ( position > 0 ) THEN
        width = filetail(position-1:position-1)
-       format(7:9) = width//'.'//width
+       format(3:5) = width//'.'//width
        WRITE(sc, format) sc1_s
     ELSE
        sc = ' '
     ENDIF
-    get_time_string = TRIM(yr)//TRIM(mo)//TRIM(dy)//TRIM(hr)//TRIM(mi)//TRIM(sc)
+    ! join the present fields, using wildcard_filename_prefix before the first one and
+    ! wildcard_filename_separator between each subsequent one (both default to "_")
+    fields(1) = yr; fields(2) = mo; fields(3) = dy
+    fields(4) = hr; fields(5) = mi; fields(6) = sc
+    get_time_string = ''
+    field_written = .FALSE.
+    DO i = 1, SIZE(fields)
+       IF ( LEN_TRIM(fields(i)) == 0 ) CYCLE
+       IF ( field_written ) THEN
+          get_time_string = TRIM(get_time_string)//TRIM(wildcard_filename_separator)//TRIM(fields(i))
+       ELSE
+          get_time_string = TRIM(get_time_string)//TRIM(wildcard_filename_prefix)//TRIM(fields(i))
+          field_written = .TRUE.
+       END IF
+    END DO
   END FUNCTION get_time_string
   ! </FUNCTION>
   ! </PRIVATE>


### PR DESCRIPTION
**Description**
The diag_manager wildcard file name feature (e.g. `outputfile%4yr%2mo%2dy%2hr`) currently joins the substituted time fields with a hardcoded `_`, producing e.g. `outputfile_1900_01_01_00`.nc. This PR adds two new `diag_manager_nml` namelist options, `wildcard_filename_prefix` and `wildcard_filename_separator`, that control the string inserted before the first substituted field and between subsequent fields, respectively. Both default to `_`, so existing behaviour is preserved.

Fixes #21 

**How Has This Been Tested?**
See [comment below](https://github.com/ACCESS-NRI/FMS/pull/22#issuecomment-5279630169)

